### PR TITLE
릴리즈 빌드에서는 에러의 리턴을 {status: "error",reason: "internal"} 바꿔서 숨기기

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub mod error {
 
         errors {
             UnknownMethod(m: hyper::Method) {
-                description("invalid_endpoint")
+                description("[SERV]invalid_endpoint")
             }
             DecodeJson(e: serde_json::Error) {
                 description("badarg")


### PR DESCRIPTION
단, [SERV]로 시작하는 에러는 reason을 보여준다